### PR TITLE
feat: Posting Service 레이어 구현

### DIFF
--- a/src/main/java/com/petstarproject/petstar/dto/PostingRequest.java
+++ b/src/main/java/com/petstarproject/petstar/dto/PostingRequest.java
@@ -1,0 +1,23 @@
+package com.petstarproject.petstar.dto;
+
+import com.petstarproject.petstar.enums.Visibility;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+import software.amazon.awssdk.annotations.NotNull;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostingRequest {
+
+    @NotNull
+    private String petId;
+
+    @NotBlank
+    private String title;
+
+    String content;
+
+    private Visibility visibility; // null 이면 PUBLIC
+}

--- a/src/main/java/com/petstarproject/petstar/dto/PostingResponse.java
+++ b/src/main/java/com/petstarproject/petstar/dto/PostingResponse.java
@@ -1,0 +1,31 @@
+package com.petstarproject.petstar.dto;
+
+import com.petstarproject.petstar.entity.Posting;
+import com.petstarproject.petstar.enums.Visibility;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class PostingResponse {
+    private String id;
+    private String petId;
+    private String ownerId;
+    private String title;
+    private String content;
+    private Visibility visibility;
+    private int likeCount;
+    private int commentCount;
+    private List<String> imageKeys;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime publishedAt;
+
+    public static PostingResponse from(Posting posting) {
+        return PostingResponse.builder().build();
+    }
+
+}

--- a/src/main/java/com/petstarproject/petstar/dto/PostingResponse.java
+++ b/src/main/java/com/petstarproject/petstar/dto/PostingResponse.java
@@ -25,7 +25,20 @@ public class PostingResponse {
     private LocalDateTime publishedAt;
 
     public static PostingResponse from(Posting posting) {
-        return PostingResponse.builder().build();
+        return PostingResponse.builder()
+                .id(posting.getId())
+                .petId(posting.getPetId())
+                .ownerId(posting.getOwnerId())
+                .title(posting.getTitle())
+                .content(posting.getContent())
+                .visibility(posting.getVisibility())
+                .likeCount(posting.getLikeCount())
+                .commentCount(posting.getCommentCount())
+                .imageKeys(posting.getImageKeys())
+                .createdAt(posting.getCreatedAt())
+                .updatedAt(posting.getUpdatedAt())
+                .publishedAt(posting.getPublishedAt())
+                .build();
     }
 
 }

--- a/src/main/java/com/petstarproject/petstar/dto/VideoResponse.java
+++ b/src/main/java/com/petstarproject/petstar/dto/VideoResponse.java
@@ -27,8 +27,8 @@ public class VideoResponse {
     private LocalDateTime publishedAt;
 
     public static VideoResponse from(Video video) {
-        return VideoResponse.builder().
-                id(video.getId())
+        return VideoResponse.builder()
+                .id(video.getId())
                 .petId(video.getPetId())
                 .ownerId(video.getOwnerId())
                 .title(video.getTitle())

--- a/src/main/java/com/petstarproject/petstar/service/FileStorageService.java
+++ b/src/main/java/com/petstarproject/petstar/service/FileStorageService.java
@@ -5,4 +5,5 @@ import org.springframework.web.multipart.MultipartFile;
 public interface FileStorageService {
     String upload(MultipartFile file, String key);
 
+    void delete(String key);
 }

--- a/src/main/java/com/petstarproject/petstar/service/FileStorageService.java
+++ b/src/main/java/com/petstarproject/petstar/service/FileStorageService.java
@@ -2,8 +2,12 @@ package com.petstarproject.petstar.service;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface FileStorageService {
     String upload(MultipartFile file, String key);
 
     void delete(String key);
+
+    void deleteAll(List<String> keys);
 }

--- a/src/main/java/com/petstarproject/petstar/service/PostingService.java
+++ b/src/main/java/com/petstarproject/petstar/service/PostingService.java
@@ -1,0 +1,18 @@
+package com.petstarproject.petstar.service;
+
+import com.petstarproject.petstar.dto.PostingRequest;
+import com.petstarproject.petstar.entity.Posting;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface PostingService {
+
+    String createPosting(PostingRequest request, List<MultipartFile> images, String requesterId);
+
+    Posting getPosting(String postingId, String requesterId);
+
+    Posting updatePosting(String postingId, PostingRequest request, String requesterId);
+
+    void deletePosting(String postingId, String requesterId);
+}

--- a/src/main/java/com/petstarproject/petstar/service/PostingServiceImpl.java
+++ b/src/main/java/com/petstarproject/petstar/service/PostingServiceImpl.java
@@ -6,6 +6,7 @@ import com.petstarproject.petstar.enums.Visibility;
 import com.petstarproject.petstar.repository.PostingRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 public class PostingServiceImpl implements PostingService {
 
@@ -64,7 +66,10 @@ public class PostingServiceImpl implements PostingService {
         } catch (RuntimeException e) {
             // 업로드된 파일이 있다면 보상 삭제(롤백)
             for (String key : uploadedKeys) {
-                try { fileStorageService.delete(key); } catch (Exception ignored) {}
+                try { fileStorageService.delete(key); }
+                catch (Exception deleteEx) {
+                    log.warn("임시저장 이미지 삭제 실패: postingId={}, key={}", postingId, key, deleteEx);
+                }
             }
             throw e;
         }
@@ -110,9 +115,8 @@ public class PostingServiceImpl implements PostingService {
         checkOwner(posting.getOwnerId(), requesterId);
 
         // s3 이미지 삭제
-        for (String key : posting.getImageKeys()) {
-            try { fileStorageService.delete(key); } catch (Exception ignored) {}
-        }
+        fileStorageService.deleteAll(posting.getImageKeys());
+
         // 엔티티 삭제
         postingRepository.delete(posting);
     }

--- a/src/main/java/com/petstarproject/petstar/service/PostingServiceImpl.java
+++ b/src/main/java/com/petstarproject/petstar/service/PostingServiceImpl.java
@@ -1,0 +1,130 @@
+package com.petstarproject.petstar.service;
+
+import com.petstarproject.petstar.dto.PostingRequest;
+import com.petstarproject.petstar.dto.PostingResponse;
+import com.petstarproject.petstar.entity.Posting;
+import com.petstarproject.petstar.entity.Video;
+import com.petstarproject.petstar.enums.Visibility;
+import com.petstarproject.petstar.repository.PostingRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class PostingServiceImpl implements PostingService {
+
+    private final PostingRepository postingRepository;
+    private final FileStorageService fileStorageService;
+
+    @Autowired
+    public PostingServiceImpl(PostingRepository postingRepository, FileStorageService fileStorageService) {
+        this.postingRepository = postingRepository;
+        this.fileStorageService = fileStorageService;
+    }
+
+    @Override
+    @Transactional
+    public String createPosting(PostingRequest request,
+                                 List<MultipartFile> images,
+                                 String requesterId) {
+        String postingId = UUID.randomUUID().toString();
+
+        List<String> uploadedKeys = new ArrayList<>();
+        try {
+            // 이미지 업로드
+            if (images != null) {
+                for (MultipartFile image : images) {
+                    if (image == null || image.isEmpty()) continue;
+
+                    String key = String.format("posts/%s/images/%s", postingId, UUID.randomUUID());
+                    uploadedKeys.add(fileStorageService.upload(image, key));
+                }
+            }
+
+            // 엔티티 생성
+            Posting posting = Posting.create(
+                    postingId,
+                    request.getPetId(),
+                    requesterId,
+                    request.getTitle(),
+                    request.getContent(),
+                    request.getVisibility(),
+                    uploadedKeys
+            );
+
+            // DB 저장
+            Posting saved = postingRepository.save(posting);
+
+            return saved.getId();
+
+        } catch (RuntimeException e) {
+            // 업로드된 파일이 있다면 보상 삭제(롤백)
+            for (String key : uploadedKeys) {
+                try { fileStorageService.delete(key); } catch (Exception ignored) {}
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public Posting getPosting(String postingId, String requesterId) {
+        // 엔티티 조회
+        Posting posting = postingRepository.findById(postingId)
+                .orElseThrow(() -> new EntityNotFoundException("Posting not found: " + postingId));
+
+        // 권한 검증
+        if (posting.getVisibility() == Visibility.PRIVATE) {
+            checkOwner(posting.getOwnerId(), requesterId);
+        }
+
+        return posting;
+    }
+
+    @Override
+    @Transactional
+    public Posting updatePosting(String postingId, PostingRequest request, String requesterId) {
+        // 엔티티 조회
+        Posting posting = postingRepository.findById(postingId)
+                .orElseThrow(() -> new EntityNotFoundException("Posting not found: " + postingId));
+
+        //권한 검증
+        checkOwner(posting.getOwnerId(), requesterId);
+
+        // 정보 업데이트
+        posting.updateMeta(request.getTitle(), request.getContent(), request.getVisibility());
+
+        return posting;
+    }
+
+    @Override
+    public void deletePosting(String postingId, String requesterId) {
+        // 엔티티 조회
+        Posting posting = postingRepository.findById(postingId)
+                .orElseThrow(() -> new EntityNotFoundException("Posting not found: " + postingId));
+
+        // 권한 검증
+        checkOwner(posting.getOwnerId(), requesterId);
+
+        // s3 이미지 삭제
+        for (String key : posting.getImageKeys()) {
+            try { fileStorageService.delete(key); } catch (Exception ignored) {}
+        }
+        // 엔티티 삭제
+        postingRepository.delete(posting);
+    }
+
+    private void checkOwner(String ownerId, String requesterId) {
+        if (requesterId == null || requesterId.isBlank()) {
+            throw new RuntimeException("인증이 필요합니다."); // SpringSecurity 추가 전 임시 코드
+//            throw new AccessDeniedException("authentication required");
+        }
+        if (!requesterId.equals(ownerId)) {
+            throw new RuntimeException("본인이 만든 동영상이 아닙니다."); // SpringSecurity 추가 전 임시 코드
+//            throw new AccessDeniedException("not owner");
+        }
+    }
+}

--- a/src/main/java/com/petstarproject/petstar/service/PostingServiceImpl.java
+++ b/src/main/java/com/petstarproject/petstar/service/PostingServiceImpl.java
@@ -1,20 +1,20 @@
 package com.petstarproject.petstar.service;
 
 import com.petstarproject.petstar.dto.PostingRequest;
-import com.petstarproject.petstar.dto.PostingResponse;
 import com.petstarproject.petstar.entity.Posting;
-import com.petstarproject.petstar.entity.Video;
 import com.petstarproject.petstar.enums.Visibility;
 import com.petstarproject.petstar.repository.PostingRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@Service
 public class PostingServiceImpl implements PostingService {
 
     private final PostingRepository postingRepository;

--- a/src/main/java/com/petstarproject/petstar/service/S3FileStorageService.java
+++ b/src/main/java/com/petstarproject/petstar/service/S3FileStorageService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import java.io.IOException;
 
@@ -57,5 +59,25 @@ public class S3FileStorageService implements FileStorageService{
             throw new FileStorageException("파일 업로드 중 오류가 발생했습니다.", e);
         }
 
+    }
+
+    /**
+     * 지정된 key의 객체를 S3 버킷에서 삭제합니다.
+     *
+     * @param key 삭제할 S3 객체 key
+     * @throws FileStorageException 삭제 중 오류가 발생한 경우
+     */
+    @Override
+    public void delete(String key) {
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(request);
+        } catch (S3Exception e) {
+            throw new FileStorageException("파일 삭제 중 오류가 발생했습니다.", e);
+        }
     }
 }

--- a/src/main/java/com/petstarproject/petstar/service/S3FileStorageService.java
+++ b/src/main/java/com/petstarproject/petstar/service/S3FileStorageService.java
@@ -1,16 +1,16 @@
 package com.petstarproject.petstar.service;
 
 import com.petstarproject.petstar.exception.FileStorageException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * AWS S3에 파일을 업로드하는 {@link FileStorageService} 구현체입니다.
@@ -19,6 +19,7 @@ import java.io.IOException;
  * S3 버킷에 객체(파일)를 저장합니다. 업로드가 성공하면 해당 key를 반환하며,
  * 업로드 과정에서 IOException이 발생할 경우 {@link FileStorageException}을 발생시킵니다.</p>
  */
+@Slf4j
 @Service
 public class S3FileStorageService implements FileStorageService{
 
@@ -78,6 +79,38 @@ public class S3FileStorageService implements FileStorageService{
             s3Client.deleteObject(request);
         } catch (S3Exception e) {
             throw new FileStorageException("파일 삭제 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    @Override
+    public void deleteAll(List<String> keys) {
+        if (keys == null || keys.isEmpty()) return;
+
+        try {
+            List<ObjectIdentifier> objects = keys.stream()
+                    .map(k -> ObjectIdentifier.builder().key(k).build())
+                    .toList();
+
+            Delete delete = Delete.builder()
+                    .objects(objects)
+                    .build();
+
+            DeleteObjectsRequest request = DeleteObjectsRequest.builder()
+                    .bucket(bucket)
+                    .delete(delete)
+                    .build();
+
+            DeleteObjectsResponse response = s3Client.deleteObjects(request);
+
+            // 부분 실패 처리
+            if (response.hasErrors() && !response.errors().isEmpty()) {
+                for (S3Error err : response.errors()) {
+                    log.warn("S3 배치 삭제 실패: key={}, code={}, message={}",
+                            err.key(), err.code(), err.message());
+                }
+            }
+        } catch (S3Exception e) {
+            throw new FileStorageException("파일 일괄 삭제 중 오류가 발생했습니다.", e);
         }
     }
 }

--- a/src/test/java/com/petstarproject/petstar/service/PostingServiceImplTest.java
+++ b/src/test/java/com/petstarproject/petstar/service/PostingServiceImplTest.java
@@ -1,0 +1,333 @@
+package com.petstarproject.petstar.service;
+
+import com.petstarproject.petstar.dto.PostingRequest;
+import com.petstarproject.petstar.entity.Posting;
+import com.petstarproject.petstar.enums.Visibility;
+import com.petstarproject.petstar.repository.PostingRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostingServiceImplTest {
+
+    @Mock
+    PostingRepository postingRepository;
+
+    @Mock
+    FileStorageService fileStorageService;
+
+    @InjectMocks
+    PostingServiceImpl postingService;
+
+
+    @Test
+    @DisplayName("Posting 생성 시 이미지 업로드 수 만큼 FileStorageService.upload가 호출되고 PostingRepository.save가 호출된다")
+    void createPosting_success() {
+        // given
+        String petId = "test_pet_id";
+        String ownerId = "test_owner_id";
+
+        PostingRequest req = PostingRequest.builder()
+                .petId(petId)
+                .title("title")
+                .content("content")
+                .visibility(Visibility.PUBLIC)
+                .build();
+
+        MultipartFile img1 = mock(MultipartFile.class);
+        MultipartFile img2 = mock(MultipartFile.class);
+
+        given(img1.isEmpty()).willReturn(false);
+        given(img2.isEmpty()).willReturn(false);
+
+        given(fileStorageService.upload(eq(img1), anyString()))
+                .willReturn("posts/p1/images/imgKey1");
+        given(fileStorageService.upload(eq(img2), anyString()))
+                .willReturn("posts/p1/images/imgKey2");
+
+        given(postingRepository.save(any(Posting.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        ArgumentCaptor<Posting> captor = ArgumentCaptor.forClass(Posting.class);
+
+        // when
+        String createdId = postingService.createPosting(req, List.of(img1, img2), ownerId);
+
+        // then
+        verify(fileStorageService, times(1)).upload(eq(img1), anyString());
+        verify(fileStorageService, times(1)).upload(eq(img2), anyString());
+
+        verify(postingRepository, times(1)).save(captor.capture());
+        Posting saved = captor.getValue();
+
+        assertThat(createdId).isEqualTo(saved.getId());
+        assertThat(saved.getPetId()).isEqualTo(petId);
+        assertThat(saved.getOwnerId()).isEqualTo(ownerId);
+        assertThat(saved.getTitle()).isEqualTo("title");
+        assertThat(saved.getContent()).isEqualTo("content");
+        assertThat(saved.getVisibility()).isEqualTo(Visibility.PUBLIC);
+        assertThat(saved.getImageKeys()).containsExactly("posts/p1/images/imgKey1", "posts/p1/images/imgKey2");
+    }
+
+
+    @Test
+    @DisplayName("Posting 생성 시 이미지가 비어있으면 upload가 호출되지 않고 save는 호출된다")
+    void createPosting_success_noImages() {
+        // given
+        String petId = "test_pet_id";
+        String ownerId = "test_owner_id";
+
+        PostingRequest req = PostingRequest.builder()
+                .petId(petId)
+                .title("title")
+                .content("content")
+                .visibility(Visibility.PUBLIC)
+                .build();
+
+        given(postingRepository.save(any(Posting.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        ArgumentCaptor<Posting> captor = ArgumentCaptor.forClass(Posting.class);
+
+        // when
+        String createdId = postingService.createPosting(req, null, ownerId);
+
+        // then
+        verify(fileStorageService, never()).upload(any(), anyString());
+        verify(fileStorageService, never()).delete(anyString());
+        verify(postingRepository, times(1)).save(captor.capture());
+        Posting saved = captor.getValue();
+
+        assertThat(createdId).isNotNull();
+        assertThat(saved.getImageKeys()).isEmpty();
+    }
+
+
+    @Test
+    @DisplayName("Posting 생성 중 업로드 실패하면 이미 업로드된 파일은 delete로 롤백된다")
+    void createPosting_fail_uploadRollback() {
+        // given
+        String petId = "test_pet_id";
+        String ownerId = "test_owner_id";
+
+        PostingRequest req = PostingRequest.builder()
+                .petId(petId)
+                .title("title")
+                .content("content")
+                .visibility(Visibility.PUBLIC)
+                .build();
+
+        MultipartFile img1 = mock(MultipartFile.class);
+        MultipartFile img2 = mock(MultipartFile.class);
+
+        given(img1.isEmpty()).willReturn(false);
+        given(img2.isEmpty()).willReturn(false);
+
+        given(fileStorageService.upload(eq(img1), anyString()))
+                .willReturn("posts/p1/images/imgKey1");
+        given(fileStorageService.upload(eq(img2), anyString()))
+                .willThrow(new RuntimeException("S3 error"));
+
+        // when & then
+        assertThatThrownBy(() -> postingService.createPosting(req, List.of(img1, img2), ownerId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("S3 error");
+
+        verify(fileStorageService, times(1)).delete(eq("posts/p1/images/imgKey1"));
+        verify(fileStorageService, never()).delete("posts/p1/images/imgKey2");
+        verify(postingRepository, times(0)).save(any());
+    }
+
+
+    @Test
+    @DisplayName("Posting 단건 조회 시 Public이면 requesterId에 상관없이 PostingRepository.findById가 호출되고 응답이 반환된다")
+    void getPosting_success_public() {
+        // given
+        Posting posting = Posting.create(
+                "p1", "pet", "owner",
+                "title", "content", Visibility.PUBLIC,
+                List.of("k1", "k2")
+        );
+
+        given(postingRepository.findById("p1")).willReturn(Optional.of(posting));
+
+        // when
+        Posting res = postingService.getPosting("p1", "not-owner");
+
+        // then
+        verify(postingRepository, times(1)).findById("p1");
+        assertThat(res.getId()).isEqualTo("p1");
+        assertThat(res.getImageKeys()).containsExactly("k1", "k2");
+    }
+
+
+    @Test
+    @DisplayName("PRIVATE Posting은 owner만 조회 가능하다 (requester == owner)")
+    void getPosting_success_private_owner() {
+        // given
+        Posting posting = Posting.create(
+                "p1", "pet", "owner",
+                "title", "content", Visibility.PRIVATE,
+                List.of("k1", "k2")
+        );
+
+        given(postingRepository.findById("p1")).willReturn(Optional.of(posting));
+
+        // when
+        Posting res = postingService.getPosting("p1", "owner");
+
+        // then
+        assertThat(res.getId()).isEqualTo("p1");
+        verify(postingRepository, times(1)).findById("p1");
+    }
+
+
+    @Test
+    @DisplayName("PRIVATE Posting은 owner가 아니면 AccessDeniedException을 발생시킨다.")
+    void getPosting_fail_private_notOwner() {
+        // given
+        Posting posting = Posting.create(
+                "p1", "pet", "owner",
+                "title", "content", Visibility.PRIVATE,
+                List.of("k1", "k2")
+        );
+
+        given(postingRepository.findById("p1")).willReturn(Optional.of(posting));
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> postingService.getPosting("p1", "not_owner"))
+                .isInstanceOf(RuntimeException.class); // todo: SpringSecurity 추가후 AccessDeniedException으로 수정
+
+        verify(postingRepository, times(1)).findById("p1");
+    }
+
+
+    @Test
+    @DisplayName("Posting 단건 조회 시 존재하지 않으면 EntityNotFoundException 발생")
+    void getPosting_fail_notFound() {
+        // given
+        given(postingRepository.findById("p1")).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> postingService.getPosting("p1", "any_requester"))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(postingRepository, times(1)).findById("p1");
+    }
+
+
+    @Test
+    @DisplayName("Posting 수정 시 title/content/visibility만 변경된다")
+    void updatePosting_success() {
+        // given
+        Posting posting = Posting.create(
+                "posting-1", "pet", "owner",
+                "oldTitle", "oldContent", Visibility.PUBLIC,
+                List.of("k1", "k2")
+        );
+
+        given(postingRepository.findById("posting-1")).willReturn(Optional.of(posting));
+
+        PostingRequest req = PostingRequest.builder()
+                .petId("pet-1")
+                .title("newTitle")
+                .content("newContent")
+                .visibility(Visibility.PRIVATE)
+                .build();
+
+        // when
+        var res = postingService.updatePosting("posting-1", req, "owner");
+
+        // then
+        verify(postingRepository, times(1)).findById("posting-1");
+        verify(fileStorageService, times(0)).upload(any(), anyString());
+        verify(fileStorageService, times(0)).delete(anyString());
+
+        assertThat(res.getTitle()).isEqualTo("newTitle");
+        assertThat(res.getContent()).isEqualTo("newContent");
+        assertThat(res.getVisibility()).isEqualTo(Visibility.PRIVATE);
+        assertThat(res.getImageKeys()).containsExactly("k1", "k2");
+    }
+
+
+    @Test
+    @DisplayName("Posting 수정 시 작성자가 아니면 AccessDeniedException 발생")
+    void updatePosting_fail_notOwner() {
+        // given
+        Posting posting = Posting.create(
+                "p1", "pet", "owner",
+                "oldTitle", "oldContent", Visibility.PUBLIC,
+                List.of("k1", "k2")
+        );
+
+        given(postingRepository.findById("p1")).willReturn(Optional.of(posting));
+        PostingRequest req = mock(PostingRequest.class);
+
+        // when & then
+        assertThatThrownBy(() -> postingService.updatePosting("p1", req, "not_owner"))
+                .isInstanceOf(RuntimeException.class); // todo: 추후 AccessDeniedException으로 수정 예정
+
+        verify(postingRepository, times(1)).findById("p1");
+        verify(fileStorageService, never()).upload(any(), anyString());
+        verify(postingRepository, never()).save(any());
+    }
+
+
+    @Test
+    @DisplayName("Posting 삭제 시 S3 delete가 이미지 수 만큼 호출되고 PostingRepository.delete가 호출된다")
+    void deletePosting_success() {
+        // given
+        Posting posting = Posting.create(
+                "p1", "pet", "owner",
+                "title", "content", Visibility.PUBLIC,
+                List.of("k1", "k2")
+        );
+
+        given(postingRepository.findById("p1")).willReturn(Optional.of(posting));
+
+        // when
+        postingService.deletePosting("p1", "owner");
+
+        // then
+        verify(fileStorageService, times(1)).delete("k1");
+        verify(fileStorageService, times(1)).delete("k2");
+        verify(postingRepository, times(1)).delete(posting);
+    }
+
+
+    @Test
+    @DisplayName("Posting 삭제 시 작성자가 아니면 ForbiddenException 발생하고 delete 호출이 없다")
+    void deletePosting_forbidden() {
+        // given
+        Posting posting = Posting.create(
+                "p1", "pet", "owner",
+                "title", "content", Visibility.PUBLIC,
+                List.of("k1")
+        );
+        given(postingRepository.findById("p1")).willReturn(Optional.of(posting));
+
+        // when & then
+        assertThatThrownBy(() -> postingService.deletePosting("p1", "not_owner"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(postingRepository, times(0)).delete(any());
+        verify(fileStorageService, times(0)).delete(anyString());
+    }
+}

--- a/src/test/java/com/petstarproject/petstar/service/PostingServiceImplTest.java
+++ b/src/test/java/com/petstarproject/petstar/service/PostingServiceImplTest.java
@@ -306,8 +306,7 @@ class PostingServiceImplTest {
         postingService.deletePosting("p1", "owner");
 
         // then
-        verify(fileStorageService, times(1)).delete("k1");
-        verify(fileStorageService, times(1)).delete("k2");
+        verify(fileStorageService, times(1)).deleteAll(eq(List.of("k1", "k2")));
         verify(postingRepository, times(1)).delete(posting);
     }
 


### PR DESCRIPTION
- PostingService 인터페이스 추가
- PostingServiceImpl 구현 (CRUD + 이미지 업로드)
- PostingServiceImplTest 작성 및 테스트 통과
- PostingRequest/Response DTO 추가
- FileStorageService delete 메서드 확장
- S3FileStorageService delete 기능 구현

#### 이 PR은 feature/13-posting-domain-repository-clean(엔티티/레포 PR)에 의존합니다. 해당 PR 머지 후 머지해주세요.